### PR TITLE
Change: Remove shortcuts until properly implemented

### DIFF
--- a/src/qua_dashboards/video_mode/tab_controllers/annotation_tab_controller.py
+++ b/src/qua_dashboards/video_mode/tab_controllers/annotation_tab_controller.py
@@ -52,8 +52,6 @@ class AnnotationTabController(BaseTabController):
     _IMPORT_LIVE_FRAME_BUTTON_SUFFIX = "import-live-frame-button"
     _LOAD_FROM_DISK_BUTTON_SUFFIX = "load-from-disk-button"
     _LOAD_FROM_DISK_INPUT_SUFFIX = "load-from-disk-input"
-    _SHORTCUT_DUMMY_INPUT_SUFFIX = "shortcuts-dummy-input"
-    _SHORTCUT_DUMMY_OUTPUT_SUFFIX = "shortcuts-dummy-output"
 
     def __init__(
         self,
@@ -141,9 +139,9 @@ class AnnotationTabController(BaseTabController):
         """Generates the Dash layout for the Annotation tab."""
         logger.debug(f"Generating layout for {self.component_id}")
         radio_options = [
-            {"label": "Add/Move Points (Shift+P)", "value": "point"},
-            {"label": "Add Lines (Shift+L)", "value": "line"},
-            {"label": "Delete (Shift+D)", "value": "delete"},
+            {"label": "Add/Move Points", "value": "point"},
+            {"label": "Add Lines", "value": "line"},
+            {"label": "Delete", "value": "delete"},
         ]
 
         controls_layout = dbc.CardBody(
@@ -219,16 +217,7 @@ class AnnotationTabController(BaseTabController):
             ]
         )
 
-        other_components = [
-            html.Div(
-                id=self._get_id(self._SHORTCUT_DUMMY_INPUT_SUFFIX),
-                style={"display": "none"},
-            ),
-            html.Div(
-                id=self._get_id(self._SHORTCUT_DUMMY_OUTPUT_SUFFIX),
-                style={"display": "none"},
-            ),
-        ]
+        other_components = []
 
         return html.Div(
             [
@@ -368,7 +357,6 @@ class AnnotationTabController(BaseTabController):
             app, viewer_data_store_id, orchestrator_stores
         )
         self._register_analysis_callback(app, viewer_data_store_id)
-        self._register_shortcut_callback(app)
 
     def _register_import_live_frame_callback(
         self,
@@ -748,57 +736,6 @@ class AnnotationTabController(BaseTabController):
             if slopes:
                 return json.dumps(slopes, indent=2)
             return "No lines to analyze or error in calculation."
-
-    def _register_shortcut_callback(self, app: Dash) -> None:
-        """Client-side callback for handling keyboard shortcuts."""
-        app.clientside_callback(
-            f"""
-            function(dummy_input_value) {{
-                const componentId = '{self.component_id}';
-                const listenerAttachedFlag = `annotationKeyListenerAttached_${{componentId}}`;
-                const modeSelectorIdObj = {json.dumps(self._get_id(self._MODE_SELECTOR_SUFFIX))};
-
-                if (!window[listenerAttachedFlag]) {{
-                     const handleKeyDown = function(event) {{
-                        const activeElement = document.activeElement;
-                        const isInputFocused = activeElement &&
-                            (activeElement.tagName === 'INPUT' ||
-                             activeElement.tagName === 'TEXTAREA' ||
-                             activeElement.isContentEditable);
-
-                        let modeSelectorElement = document.getElementById(JSON.stringify(modeSelectorIdObj));
-                        if (!modeSelectorElement) {{ return; }}
-                        
-                        const isTabActive = modeSelectorElement.offsetParent !== null;
-
-                        if (event.shiftKey && !isInputFocused && isTabActive) {{
-                            let key = event.key.toLowerCase();
-                            let mapping = {{"p": "point", "l": "line", "d": "delete"}};
-                            if (mapping.hasOwnProperty(key)) {{
-                                event.preventDefault();
-                                try {{
-                                    dash_clientside.set_props(modeSelectorIdObj, {{value: mapping[key]}});
-                                }} catch (e) {{
-                                     console.error(`Error setting mode selector for ${{componentId}}:`, e);
-                                }}
-                            }}
-                        }}
-                    }};
-                    document.addEventListener("keydown", handleKeyDown);
-                    window[listenerAttachedFlag] = true;
-                }}
-                return window.dash_clientside.no_update;
-            }}
-            """,
-            Output(
-                component_id=self._get_id(self._SHORTCUT_DUMMY_OUTPUT_SUFFIX),
-                component_property="children",
-            ),
-            Input(
-                component_id=self._get_id(self._SHORTCUT_DUMMY_INPUT_SUFFIX),
-                component_property="children",
-            ),
-        )
 
     def _register_load_from_disk_callback(
         self,


### PR DESCRIPTION
@domess I propose we remove the javascript shortcuts until they are working and are limited to only work when in the annotation tab.
This will allow us to prepare a next release.

Related to #8. I will add the original code to that issue so it's easier to implement properly later on