### PR TITLE
Fix: Legend Appears During Annotation and Affects Layout (Issue #15)

### DIFF
--- a/src/qua_dashboards/video_mode/shared_viewer_component.py
+++ b/src/qua_dashboards/video_mode/shared_viewer_component.py
@@ -255,6 +255,7 @@ class SharedViewerComponent(BaseComponent):
                         f"for key '{data_key}'."
                     )
                     fig_to_display = self._create_figure_from_static_data(data_object)
+                    fig_to_display.update_layout(showlegend=False)
                 else:
                     logger.warning(
                         f"SharedViewer ({self.component_id}): Unrecognized data key "

--- a/src/qua_dashboards/video_mode/utils/dash_utils.py
+++ b/src/qua_dashboards/video_mode/utils/dash_utils.py
@@ -44,6 +44,7 @@ def xarray_to_plotly(da: xr.DataArray):
             y=y_coord.values,
             colorscale="plasma",
             colorbar=dict(title=zaxis_label),
+            hovertemplate="x: %{x}<br>y: %{y}<br>z: %{z}<extra></extra>"
         )
     )
     fig.update_layout(


### PR DESCRIPTION
The legend is removed completely when adding points and labels in the annotation tab. This fixes Issue #15

Moreover, the trace name is removed when hovering over the heatmap, again, to avoid unnecessary visual clutter.