### PR TITLE
Fix: Regenerate QUA program when span or points change

### DIFF
--- a/src/qua_dashboards/video_mode/sweep_axis.py
+++ b/src/qua_dashboards/video_mode/sweep_axis.py
@@ -137,11 +137,10 @@ class SweepAxis(BaseUpdatableComponent):
 
         params = parameters[self.component_id]
 
-        # X-axis
         if "span" in params and self.span != params["span"]:
             self.span = params["span"]
-            flags |= ModifiedFlags.PARAMETERS_MODIFIED
+            flags |= ModifiedFlags.PARAMETERS_MODIFIED | ModifiedFlags.PROGRAM_MODIFIED
         if "points" in params and self.points != params["points"]:
             self.points = params["points"]
-            flags |= ModifiedFlags.PARAMETERS_MODIFIED
+            flags |= ModifiedFlags.PARAMETERS_MODIFIED | ModifiedFlags.PROGRAM_MODIFIED
         return flags


### PR DESCRIPTION
Previously, an error caused the program not to regenerate when the span or points changed. Thanks @KU-QM for spotting this