### PR TITLE
Bugfixing Parameters Interface & Adding a Callback to VoltageControlComponent

### DIFF
--- a/examples/voltage_control/example_voltage_control_simulated.py
+++ b/examples/voltage_control/example_voltage_control_simulated.py
@@ -16,20 +16,23 @@ def define_gates_simple():
     ]
 
 
-def get_voltage_control_component():
+def get_voltage_control_component(callback=None):
     """Returns a VoltageControlComponent with demo gates."""
     voltage_parameters = define_gates_simple()
     voltage_controller = VoltageControlComponent(
         component_id="v_ctrl",
         voltage_parameters=voltage_parameters,
+        callback_on_param_change = callback
     )
     return voltage_controller
 
+def example_callback(parameter):
+    print("Parameter", parameter.name, "was changed to value", parameter.get_latest())
 
 def main():
     logger = setup_logging(__name__)
     logger.info("Starting Voltage Control dashboard (Simple demo mode)")
-    component = get_voltage_control_component()
+    component = get_voltage_control_component(callback=example_callback)
     app = build_dashboard(
         components=[component],
         title="Voltage Control Dashboard (Simple Demo)",

--- a/examples/voltage_control/example_voltage_control_simulated.py
+++ b/examples/voltage_control/example_voltage_control_simulated.py
@@ -9,10 +9,10 @@ from qua_dashboards.utils import setup_logging, BasicParameter
 def define_gates_simple():
     """Defines gates using SimpleVoltageSource for demo purposes."""
     return [
-        BasicParameter("vg1", "Gate 1", "V", initial_value=0),
-        BasicParameter("vg2", "Gate 2", "V", initial_value=np.random.randn()),
-        BasicParameter("vds", "Drain-Source", "V", initial_value=np.random.randn()),
-        BasicParameter("vgs", "Gate-Source", "V", initial_value=np.random.randn()),
+        BasicParameter("vg1", "Gate 1", "V", initial_value=0, delay=0.2),
+        BasicParameter("vg2", "Gate 2", "V", initial_value=np.random.randn(), delay=0.2),
+        BasicParameter("vds", "Drain-Source", "V", initial_value=np.random.randn(), delay=0.2),
+        BasicParameter("vgs", "Gate-Source", "V", initial_value=np.random.randn(), delay=0.2),
     ]
 
 

--- a/src/qua_dashboards/core/parameter_protocol.py
+++ b/src/qua_dashboards/core/parameter_protocol.py
@@ -11,6 +11,9 @@ __all__ = ["ParameterProtocol"]
 class ParameterProtocol(Protocol):
     """
     A protocol defining the expected interface for a generic parameter.
+    
+    This protocol follows exactly the semantics and names of qcodes.parameters.Parameter and therefore
+    any function expecting a class of this protocol is compatible with QCodes Parameters.
     """
 
     @property
@@ -24,7 +27,7 @@ class ParameterProtocol(Protocol):
         ...
 
     @property
-    def units(self) -> str:
+    def unit(self) -> str:
         """
         A string indicating the physical units of the parameter (e.g.,
         "V", "mV", "Hz").
@@ -33,7 +36,12 @@ class ParameterProtocol(Protocol):
 
     def get_latest(self) -> float:
         """
-        Returns the latest known or actual value of the parameter.
+        Returns the latest known chached, or actual value of the parameter.
+        """
+        ...
+    def get(self) -> float:
+        """
+        Queries the current value of the parameter.
         """
         ...
 

--- a/src/qua_dashboards/utils/__init__.py
+++ b/src/qua_dashboards/utils/__init__.py
@@ -3,6 +3,7 @@ from .dash_utils import *
 from .general_utils import *
 from .log_utils import *
 from .basic_parameter import *
+from .callback_parameter import *
 
 __all__ = [
     *data_utils.__all__,
@@ -10,4 +11,5 @@ __all__ = [
     *general_utils.__all__,
     *log_utils.__all__,
     *basic_parameter.__all__,
+    *callback_parameter.__all__,
 ]

--- a/src/qua_dashboards/utils/basic_parameter.py
+++ b/src/qua_dashboards/utils/basic_parameter.py
@@ -7,18 +7,19 @@ __all__ = ["BasicParameter"]
 
 
 class BasicParameter:
-    def __init__(self, name:str, label:Optional[str]=None, units:str="V", initial_value:float=0.0):
+    def __init__(self, name:str, label:Optional[str]=None, units:str="V", initial_value:float=0.0, delay:float = 0.0):
         self.name = name
         self.label = label if label is not None else name
         self.latest_value = initial_value
         self._value = initial_value
         self.unit = units
+        self.delay = delay
         logging.debug(
             f"{self.name} initialized with value {self.latest_value} {self.unit}"
         )
 
     def get(self):
-        time.sleep(0.2)  # Simulate a 200ms delay
+        time.sleep(self.delay)  # Simulate delay, used for examples
         self.latest_value = self._value
         logging.debug(f"Getting {self.name}: {self.latest_value} {self.unit}")
         return self.latest_value

--- a/src/qua_dashboards/utils/basic_parameter.py
+++ b/src/qua_dashboards/utils/basic_parameter.py
@@ -1,34 +1,39 @@
 import logging
 import time
-
+from typing import Callable, Optional, TYPE_CHECKING
+from qua_dashboards.core import ParameterProtocol
 
 __all__ = ["BasicParameter"]
 
 
 class BasicParameter:
-    def __init__(self, name, label=None, units="V", initial_value=0.0):
+    def __init__(self, name:str, label:Optional[str]=None, units:str="V", initial_value:float=0.0):
         self.name = name
-        self.label = label
+        self.label = label if label is not None else name
         self.latest_value = initial_value
         self._value = initial_value
-        self.units = units
+        self.unit = units
         logging.debug(
-            f"{self.name} initialized with value {self.latest_value} {self.units}"
+            f"{self.name} initialized with value {self.latest_value} {self.unit}"
         )
 
     def get(self):
         time.sleep(0.2)  # Simulate a 200ms delay
         self.latest_value = self._value
-        logging.debug(f"Getting {self.name}: {self.latest_value} {self.units}")
+        logging.debug(f"Getting {self.name}: {self.latest_value} {self.unit}")
         return self.latest_value
 
     def set(self, new_value):
         self._value = new_value
         updated_value = self.get()  # Return the value after setting
         logging.debug(
-            f"Setting {self.name} to {new_value}: Actual value is {updated_value} {self.units}"
+            f"Setting {self.name} to {new_value}: Actual value is {updated_value} {self.unit}"
         )
         return updated_value
 
     def get_latest(self):
         return self.latest_value
+
+if TYPE_CHECKING:
+    def check(name: str):
+        _:ParameterProtocol = BasicParameter(name)

--- a/src/qua_dashboards/utils/callback_parameter.py
+++ b/src/qua_dashboards/utils/callback_parameter.py
@@ -1,0 +1,39 @@
+
+from qua_dashboards.core import ParameterProtocol
+from typing import Callable, TYPE_CHECKING
+
+__all__ = ["CallbackParameter"]
+
+
+class CallbackParameter:
+    """ Calls a callback function when the value of this parameter is changed. The callback takes the parameter changed as argument."""
+
+    def __init__(self, parameter: ParameterProtocol, callback_on_set: Callable[[ParameterProtocol],None]):
+        self.parameter = parameter
+        self.callback = callback_on_set
+        
+    @property
+    def name(self) -> str:
+        return self.parameter.name
+
+    @property
+    def label(self) -> str:
+        return self.parameter.label
+        
+    @property
+    def unit(self) -> str:
+        return self.parameter.unit
+
+    def get_latest(self) -> float:
+        return self.parameter.get_latest()
+    
+    def get(self) -> float:
+        return self.parameter.get()
+
+    def set(self, value: float) -> None:
+        self.parameter.set(value)
+        self.callback(self.parameter)
+        
+if TYPE_CHECKING:
+    def check(parameter: ParameterProtocol, callback_on_set: Callable[[ParameterProtocol], None]):
+        _: ParameterProtocol = CallbackParameter(parameter, callback_on_set)

--- a/src/qua_dashboards/voltage_control/voltage_control_component.py
+++ b/src/qua_dashboards/voltage_control/voltage_control_component.py
@@ -14,6 +14,7 @@ from dash import (
 )
 
 from qua_dashboards.core import BaseComponent, ParameterProtocol
+from qua_dashboards.utils import CallbackParameter
 
 from .voltage_control_row import VoltageControlRow, format_voltage
 
@@ -36,9 +37,14 @@ class VoltageControlComponent(BaseComponent):
         voltage_parameters: Sequence[ParameterProtocol],
         update_interval_ms: int = 1000,
         layout_columns: int = 3,
+        callback_on_param_change = None
+        
     ):
         super().__init__(component_id=component_id)
         self.voltage_parameters = voltage_parameters
+        #wrap parameters to trigger callbacks on change.
+        if callback_on_param_change is not None:
+            self.voltage_parameters = [CallbackParameter(param, callback_on_param_change) for param in self.voltage_parameters]
         self.update_interval_ms = update_interval_ms
 
         self._initial_values_loaded = False  # To ensure first update populates values

--- a/src/qua_dashboards/voltage_control/voltage_control_row.py
+++ b/src/qua_dashboards/voltage_control/voltage_control_row.py
@@ -103,7 +103,7 @@ class VoltageControlRow:
                 ),
                 dbc.Col(
                     dbc.Label(
-                        children=self.param.units, style={"whiteSpace": "nowrap"}
+                        children=self.param.unit, style={"whiteSpace": "nowrap"}
                     ),
                     style={
                         "width": UNITS_WIDTH,


### PR DESCRIPTION
This PR adds a few bug fixes and improvements to Parameters:

1. the ParameterProtocol now mirrors exactly QCodes Parameters and fix a few smaller follow-up problems. A result of this is that some function are renamed. I ensured backwards compatibility for naive usage by keeping constructor parameter names the same (e.g. the member variable name changed units->unit, but the old parameter name "units" is kept in the constructor.
2. added and fixed static type checking to BasicParameter. This scheme can be mirrored in any other file in the repo.
3. the delay in BasicParameter is now configurable and zero by default to make it more general


Further, it adds a new feature which allows `VoltageControlComponent `  callback if any of the parameters is changed via ParameterProtocol.set(). This is necessary because we might want to inform the data acquirer if any of the parameters are changed. for example a change of a plunger gate could trigger deletion of history. The Implementation is done via a new class `CallbackParameter` which just wraps ParameterProtocol.set() and calls the callback with the changed parameter provided as argument. This seemed to be the least invasive way. TypeChecking was also added here.