### PR TITLE
Feat/save quam state

### DIFF
--- a/examples/video_mode/example_video_mode_opx.py
+++ b/examples/video_mode/example_video_mode_opx.py
@@ -145,7 +145,7 @@ data_acquirer = OPXDataAcquirer(
 # %% Run Video Mode Dashboard
 
 # Instantiate the main VideoModeComponent, providing the configured data_acquirer.
-save_path = 'C:\Users\ ...'
+save_path = r'C:\Users\ ...'
 video_mode_component = VideoModeComponent(
     data_acquirer=data_acquirer,
     data_polling_interval_s=0.5, 

--- a/src/qua_dashboards/video_mode/video_mode_component.py
+++ b/src/qua_dashboards/video_mode/video_mode_component.py
@@ -235,6 +235,15 @@ class VideoModeComponent(BaseComponent):
                     ),
                     width=4,
                 ),
+                dbc.Col(
+                    dcc.Input(
+                        value = self.save_path,
+                        id = self._get_id("save-quam-path"), 
+                        className="form-control me-2 w-150",
+                        debounce=True,
+                        placeholder= r"C:/Users/ ... "
+                    )
+                )
             ],
             className="mb-3 g-2 justify-content-start",
         )
@@ -432,7 +441,22 @@ class VideoModeComponent(BaseComponent):
                 message,
                 color=color,
                 dismissable=True,
-    )
+            )
+        @app.callback(
+            Output(self._get_id(self._MAIN_STATUS_ALERT_ID_SUFFIX), "children", allow_duplicate = True), 
+            Input(self._get_id("save-quam-path"), "value"), 
+            prevent_initial_call = True
+        )
+        def set_quam_state_path(input_path):
+            if not input_path:
+                raise PreventUpdate
+            self.save_path = input_path
+            return dbc.Alert(
+                f"Save Path Updated to {input_path}", 
+                color = "info", 
+                dismissable = True, 
+                duration = 2000
+            )
 
     def _register_data_polling_interval_callback(self, app: Dash) -> None:
         """Registers callback for periodically polling the data acquirer."""


### PR DESCRIPTION
Add a save quam state button. Path specified in the script. Added functionality to input a path to an input field next to save state button. Currently no verification of path legitimacy; if path is non-existent, this will fail when attempting to save QUAM state. Also currently no functionality to create directories (Reckon this might just be annoying for people who make typos). 