### PR TITLE
Click to centre

### DIFF
--- a/src/qua_dashboards/video_mode/data_acquirers/opx_data_acquirer.py
+++ b/src/qua_dashboards/video_mode/data_acquirers/opx_data_acquirer.py
@@ -115,8 +115,8 @@ class OPXDataAcquirer(Base2DDataAcquirer):
         """
         Generates the QUA program for the 2D scan.
         """
-        x_qua_values = list(self.x_axis.sweep_values_unattenuated)
-        y_qua_values = list(self.y_axis.sweep_values_unattenuated)
+        x_qua_values = list(self.x_axis.sweep_values_with_offset)
+        y_qua_values = list(self.y_axis.sweep_values_with_offset)
 
         with program() as prog:
             qua_streams = {var: declare_stream() for var in self.stream_vars}

--- a/src/qua_dashboards/video_mode/video_mode_component.py
+++ b/src/qua_dashboards/video_mode/video_mode_component.py
@@ -338,7 +338,7 @@ class VideoModeComponent(BaseComponent):
                 "orchestrator_stores": orchestrator_stores_for_tabs,
                 "shared_viewer_store_ids": shared_viewer_store_ids_for_tabs,
             }
-            if isinstance(tc, AnnotationTabController):
+            if isinstance(tc, (AnnotationTabController, LiveViewTabController)):
                 callback_kwargs_for_tab["shared_viewer_graph_id"] = (
                     shared_viewer_graph_actual_id
                 )


### PR DESCRIPTION
Functionality to double click to centre OPX offset; does not work for systems which use bias tees. 

Changes: 
- Store the graph ID in the live view tab
- Allow double clicks to update data_acquirer axis (sweepaxis) offset_parameters 