### PR TITLE
Fixed resolution change bug

### DIFF
--- a/src/qua_dashboards/video_mode/data_acquirers/base_2d_data_acquirer.py
+++ b/src/qua_dashboards/video_mode/data_acquirers/base_2d_data_acquirer.py
@@ -103,17 +103,15 @@ class Base2DDataAcquirer(BaseDataAcquirer):
         # Ensure shapes match the axes
         expected_shape = (self.y_axis.points, self.x_axis.points)
         if data_np.shape != expected_shape:
-            logger.warning(
+            logger.info(
                 f"{self.component_id}: Shape mismatch. Data shape is {data_np.shape}, "
                 f"but expected {expected_shape} based on axis points. "
-                f"Returning raw data. Ensure acquisition logic and axis points align."
+                f"Ignoring stale frames."
             )
             return {
                 "data": None,  # Or a default empty xarray
-                "error": ValueError(
-                    f"Shape mismatch: data {data_np.shape}, expected {expected_shape}"
-                ),
-                "status": "error",
+                "error": None,
+                "status": "pending",
             }
 
         try:


### PR DESCRIPTION
A bug where a shape mismatch error was raised for a static resolution change; and a programme crash for a dynamic resolution change. Programme will now measure the data size with the expected size. If mismatch, then will provide an output of NaNs as a placeholder until the next valid frame is received. 

In the Base2dDataAcquirer parent class, relaxed the mismatch error for a dynamic change. Changed the logger to a info rather than a warning, and removed ValueError in the error state to None. Also, status changing to intermediate pending state. 

See JIRA: https://quantum-machines.atlassian.net/browse/QUAL-1418

