### PR TITLE
Fix for pre-acquisition crash on parameter change

### DIFF
--- a/src/qua_dashboards/video_mode/data_acquirers/opx_data_acquirer.py
+++ b/src/qua_dashboards/video_mode/data_acquirers/opx_data_acquirer.py
@@ -190,6 +190,8 @@ class OPXDataAcquirer(Base2DDataAcquirer):
             self.generate_qua_program()
 
         logger.info(f"Executing QUA program for {self.component_id}.")
+        if self.qm is None:
+            self.initialize_qm()
         self.qm_job = self.qm.execute(self.qua_program)  # type: ignore
 
         if validate_running:


### PR DESCRIPTION
Small fix to address programme crash when parameters are changed before the QM is opened, i.e. pre-acquisition. Just a safe-guard to re-initialise the QM if QM is None