### PR TITLE
1dSweeps with GateSet implementation

### DIFF
--- a/src/qua_dashboards/video_mode/inner_loop_actions/basic_inner_loop_action.py
+++ b/src/qua_dashboards/video_mode/inner_loop_actions/basic_inner_loop_action.py
@@ -51,7 +51,10 @@ class BasicInnerLoopAction(InnerLoopAction):
         self, x: QuaVariableFloat, y: QuaVariableFloat
     ) -> Tuple[QuaVariableFloat, QuaVariableFloat]:
         # Map sweep values to named channels via axis names
-        levels = {self.x_axis_name: x, self.y_axis_name: y}
+        if y is None: 
+            levels = {self.x_axis_name: x}
+        else:
+            levels = {self.x_axis_name: x, self.y_axis_name: y}
 
         duration = self.readout_pulse.length
         if self.pre_measurement_delay > 0:

--- a/src/qua_dashboards/video_mode/scan_modes/__init__.py
+++ b/src/qua_dashboards/video_mode/scan_modes/__init__.py
@@ -2,10 +2,11 @@ from .scan_mode import ScanMode
 from .raster_scan import RasterScan
 from .spiral_scan import SpiralScan
 from .switch_raster_scan import SwitchRasterScan
-
+from .line_scan import LineScan
 __all__ = [
     "ScanMode",
     "RasterScan",
     "SpiralScan",
     "SwitchRasterScan",
+    "LineScan"
 ]

--- a/src/qua_dashboards/video_mode/scan_modes/line_scan.py
+++ b/src/qua_dashboards/video_mode/scan_modes/line_scan.py
@@ -1,0 +1,28 @@
+from typing import Generator, Sequence, Tuple
+import numpy as np
+from qm.qua import declare, fixed, for_each_
+from qua_dashboards.video_mode.scan_modes import ScanMode
+from qua_dashboards.utils.qua_types import QuaVariableFloat
+
+class LineScan(ScanMode):
+    """
+    Line scan mode.
+
+    Identifies X and Y coordinates for a linescan.
+    """
+
+    def get_idxs(self, x_points: int, y_points: int) -> Tuple[np.ndarray, np.ndarray]:
+        # MINIMAL FIX: map N samples onto a 1×N frame (row 0)
+        x_idxs = np.arange(x_points, dtype=int)
+        y_idxs = np.zeros(x_points, dtype=int)
+        return x_idxs, y_idxs
+
+    def scan(
+        self, x_vals: Sequence[float], y_vals: Sequence[float]
+    ) -> Generator[Tuple[QuaVariableFloat], None, None]:
+
+        x_list = list(x_vals)
+
+        qx = declare(fixed)
+        with for_each_((qx), (x_list)):
+            yield qx, None

--- a/src/qua_dashboards/video_mode/shared_viewer_component.py
+++ b/src/qua_dashboards/video_mode/shared_viewer_component.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Any, Dict, List, Optional
-
+import numpy as np
 import plotly.graph_objects as go
 import xarray as xr
 from dash import Dash, Input, Output, State, dcc, html
@@ -116,6 +116,22 @@ class SharedViewerComponent(BaseComponent):
             return self._current_figure
 
         try:
+            if base_image_data.ndim == 2 and (1 in base_image_data.shape):
+                vals = np.asarray(base_image_data.values).ravel()
+                dims = base_image_data.dims
+                x_dim = dims[1] if base_image_data.shape[0] == 1 else dims[0]
+                coord = base_image_data.coords[x_dim]
+                x = np.asarray(coord.values)
+                x_label = coord.attrs.get("label") or str(x_dim)
+                if coord.attrs.get("units"):
+                    x_label = f"{x_label} [{coord.attrs['units']}]"
+                fig = go.Figure()
+                fig.add_trace(go.Scatter(x=x, y=vals, mode="lines"))
+                fig.update_layout(template="plotly_dark",
+                                  xaxis_title=x_label,
+                                  yaxis_title="Value")
+                self._current_figure = fig
+                return fig
             self._current_figure = xarray_to_plotly(base_image_data)
         except Exception as e:
             logger.error(
@@ -152,6 +168,22 @@ class SharedViewerComponent(BaseComponent):
 
         if isinstance(base_image_data, xr.DataArray):
             try:
+                if base_image_data.ndim == 2 and (1 in base_image_data.shape):
+                    vals = np.asarray(base_image_data.values).ravel()
+                    dims = base_image_data.dims
+                    x_dim = dims[1] if base_image_data.shape[0] == 1 else dims[0]
+                    coord = base_image_data.coords[x_dim]
+                    x = np.asarray(coord.values)
+                    x_label = coord.attrs.get("label") or str(x_dim)
+                    if coord.attrs.get("units"):
+                        x_label = f"{x_label} [{coord.attrs['units']}]"
+                    fig = go.Figure()
+                    fig.add_trace(go.Scatter(x=x, y=vals, mode="lines"))
+                    fig.update_layout(template="plotly_dark",
+                                    xaxis_title=x_label,
+                                    yaxis_title="Value")
+                    self._current_figure = fig
+                    return fig
                 fig = xarray_to_plotly(base_image_data)
             except Exception as e:
                 logger.error(

--- a/src/qua_dashboards/video_mode/tab_controllers/live_view_tab_controller.py
+++ b/src/qua_dashboards/video_mode/tab_controllers/live_view_tab_controller.py
@@ -207,16 +207,27 @@ class LiveViewTabController(BaseTabController):
 
         @app.callback(
             Output(self._get_id(self._DUMMY_OUTPUT_ACQUIRER_UPDATE_SUFFIX), "children", allow_duplicate=True), 
+            Output(self._get_id(self._ACQUIRER_CONTROLS_DIV_ID_SUFFIX), "children", allow_duplicate=True),
             Input(self._data_acquirer_instance._get_id("gate-select-x"), "value"), 
             Input(self._data_acquirer_instance._get_id("gate-select-y"), "value"), 
             prevent_initial_call = True
         )
         def on_gate_select(x_gate, y_gate):
-            logger.info(f"New Gate Selected: x_axis {x_gate}, y_axis {y_gate}")
-            self._data_acquirer_instance.x_axis_name = x_gate
-            self._data_acquirer_instance.y_axis_name = y_gate
-            self._data_acquirer_instance._compilation_flags |= ModifiedFlags.PROGRAM_MODIFIED
-            return ""
+            logger.info(f"New Gate Selected: x_axis {x_gate}, y_axis {y_gate}")           
+
+            params = {
+                self._data_acquirer_instance.component_id: {
+                    "gate-select-x": x_gate, 
+                    "gate-select-y": y_gate
+                }
+            }
+            self._data_acquirer_instance.update_parameters(params)
+
+            # self._data_acquirer_instance.x_axis_name = x_gate
+            # self._data_acquirer_instance.y_axis_name = y_gate
+            # _ = self._data_acquirer_instance.y_axis
+
+            return "", self._data_acquirer_instance.get_dash_components(include_subcomponents=True)
 
     def _register_acquisition_control_callback(
         self, app: Dash, orchestrator_stores: Dict[str, Any]


### PR DESCRIPTION
1d Sweeps to be used with GateSet. Simply empty the y-axis dropdown in order to perform a 1d scan of the X axis. 