### PR TITLE
Fix: Update pyproject to use main quam-builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "dash-dynamic-grid-layout>=0.1.3",
     "qualibrate-core>=0.3.1",
     "numpy>=1.25.2,<2.0.0",
-    "quam-builder @ git+https://github.com/qua-platform/quam-builder.git@feat/virtual-gates",
+    "quam-builder @ git+https://github.com/qua-platform/quam-builder.git",
 ]
 
 [project.urls]


### PR DESCRIPTION
Currently, it's using the virtual gates branch, which no longer exists. 